### PR TITLE
Make autoFocus behaviour configurable via prop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ export interface RadioGroupCtx<V, Siblings = V[]> {
   value: V;
   otherRadioValues: Siblings;
   setChecked: (value: any) => void;
+  autoFocus: boolean;
 }
 
 const RadioGroupContext = React.createContext<RadioGroupCtx<any>>({} as any);
@@ -31,12 +32,14 @@ export interface RadioGroupProps<V> {
   children: React.ComponentType<RadioProps<V>>[];
   value: V;
   onChange: (value: V) => void;
+  autoFocus?: boolean;
 }
 
 export function RadioGroup<V>({
   labelledBy,
   children,
   value,
+  autoFocus = false,
   ...props
 }: RadioGroupProps<V>) {
   const setChecked = React.useCallback(v => {
@@ -54,6 +57,7 @@ export function RadioGroup<V>({
       value,
       otherRadioValues,
       setChecked,
+      autoFocus,
     }),
     [otherRadioValues, value]
   );
@@ -76,18 +80,18 @@ export const Radio = React.forwardRef<HTMLDivElement | null, RadioProps<any>>(
     const ref = React.useRef<HTMLDivElement | null>(null);
 
     const ctx = React.useContext(RadioGroupContext);
-    const { otherRadioValues, value, setChecked } = ctx;
+    const { otherRadioValues, value, setChecked, autoFocus } = ctx;
     const index = otherRadioValues.findIndex(i => i == props.value);
     const count = otherRadioValues.length - 1;
     React.useEffect(() => {
-      if (value === props.value) {
+      if (autoFocus && value === props.value) {
         if (maybeOuterRef && maybeOuterRef.current !== null) {
           maybeOuterRef.current.focus();
         } else if (ref.current !== null) {
           ref.current.focus();
         }
       }
-    }, [value, props.value, maybeOuterRef]);
+    }, [value, props.value, maybeOuterRef, autoFocus]);
 
     const handleKeyDown = React.useCallback(
       event => {


### PR DESCRIPTION
This component shouldn't default to `autoFocus`, it should be configurable via a prop. If a form specifies a different input as `autoFocus`, this component will always "steal" the focus.

Unfortunately this is probably a breaking/major version change because others using this component might be _expecting_ it's default `autoFocus` behaviour.