### PR TITLE
Add tabindex 0 to first radio if no option is selected.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,8 +79,10 @@ export const Radio = React.forwardRef<HTMLDivElement | null, RadioProps<any>>(
     const { otherRadioValues, value, setChecked } = ctx;
     const index = otherRadioValues.findIndex(i => i == props.value);
     const count = otherRadioValues.length - 1;
+    const isCurrentRadioSelected = value === props.value;
+
     React.useEffect(() => {
-      if (value === props.value) {
+      if (isCurrentRadioSelected) {
         if (maybeOuterRef && maybeOuterRef.current !== null) {
           maybeOuterRef.current.focus();
         } else if (ref.current !== null) {
@@ -89,12 +91,13 @@ export const Radio = React.forwardRef<HTMLDivElement | null, RadioProps<any>>(
       }
     }, [value, props.value, maybeOuterRef]);
 
+    const isFirstRadioOption = index === 0;
     const handleKeyDown = React.useCallback(
       event => {
         event.persist();
         var flag = false;
         function setPrevious() {
-          if (index === 0) {
+          if (isFirstRadioOption) {
             setChecked(otherRadioValues[count]);
           } else {
             setChecked(otherRadioValues[index - 1]);
@@ -154,12 +157,15 @@ export const Radio = React.forwardRef<HTMLDivElement | null, RadioProps<any>>(
       }
       setFocus(true);
     }, []);
+
+    const noValueSelected = !value;
+    const tabIndex = isCurrentRadioSelected || (noValueSelected && isFirstRadioOption) ? 0 : -1;
     return (
       <div
         {...props}
         role="radio"
-        tabIndex={value === props.value ? 0 : -1}
-        aria-checked={value === props.value}
+        tabIndex={tabIndex}
+        aria-checked={isCurrentRadioSelected}
         onBlur={handleBlur}
         onFocus={handleFocus}
         onClick={handleClick}


### PR DESCRIPTION
According to the specification [here](https://www.w3.org/TR/wai-aria-practices-1.1/examples/radio/radio-1/radio-1.html) all the radio options need to have tabindex of `-1` except one. If no value is selected the first radio option should get focus on tabbing. If there is a selection then the selected option get the focus on tabbing.

This fixes #4

Update 1:
Updated the link to specification
