### PR TITLE
add 'touched' to fix autoFocus

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,7 +53,7 @@ export const RadioGroup = forwardRefWithAs<RadioGroupProps, 'div'>(
     const { onChange } = props;
     const [touched, setTouched] = React.useState(false);
     const setChecked = React.useCallback(
-      (v) => {
+      v => {
         if (onChange) {
           onChange(v);
         }
@@ -63,7 +63,7 @@ export const RadioGroup = forwardRefWithAs<RadioGroupProps, 'div'>(
 
     const otherRadioValues = React.Children.map<any, any>(
       children,
-      (child) => child.props.value
+      child => child.props.value
     );
     const ctx = React.useMemo(
       () => ({
@@ -124,7 +124,7 @@ export const Radio = forwardRefWithAs<RadioProps<any>, 'div'>(function Radio(
 
   const isFirstRadioOption = index === 0;
   const handleKeyDown = React.useCallback(
-    (event) => {
+    event => {
       event.persist();
       let flag = false;
       function setPrevious() {
@@ -186,7 +186,7 @@ export const Radio = forwardRefWithAs<RadioProps<any>, 'div'>(function Radio(
   }, [setChecked, valueProp]);
 
   const handleBlur = React.useCallback(
-    (e) => {
+    e => {
       if (onBlur) {
         onBlur(e);
       }
@@ -197,7 +197,7 @@ export const Radio = forwardRefWithAs<RadioProps<any>, 'div'>(function Radio(
   );
 
   const handleFocus = React.useCallback(
-    (e) => {
+    e => {
       if (onFocus) {
         onFocus(e);
       }
@@ -221,7 +221,7 @@ export const Radio = forwardRefWithAs<RadioProps<any>, 'div'>(function Radio(
       onKeyDown={handleKeyDown}
       data-palmerhq-radio
       data-palmerhq-radio-focus={focus}
-      ref={(el) => {
+      ref={el => {
         if (maybeOuterRef) {
           maybeOuterRef.current = el;
         }


### PR DESCRIPTION
The default 'autoFocus' should be false, so that it doesnt steal it from other explicitly set elements. Currently when the autoFocus={false} is set, the radio button selection is broken however. This is due to the logic (index#116) which focus'es an element which its value === the selected value, but currently ONLY when autoFocus === true. This needs to occur when a user has changed the value in the radio group, OR on an initial autoFocus. 
So, to differentiate that the change is after the user has interacted with the RadioGroup ive added a 'touched' state. I tried to recode local state in the Radio, that the render was 'first render', but this didnt work as multiple renders caused an in correct focus. So, actually recording a 'touch' seems logical, and works in my testing